### PR TITLE
[Add] fgets wrapper (and fix exitgame bug)

### DIFF
--- a/src/exitgame.c
+++ b/src/exitgame.c
@@ -25,8 +25,12 @@
 void exitgame(int c)
 {
     printf("\n");
-    pstrings_display("exit_penter");
-    printf("\n");
+    if(c == 0) 
+    {
+        pstrings_display("exit_penter");
+        printf("\n");
+    }
+    else puts("Press Enter to exit");
     getchar();
 
     if(c == 0) exit(c);

--- a/src/fileio/fileio.c
+++ b/src/fileio/fileio.c
@@ -28,3 +28,29 @@ void fileio_setfileptr(FILE** fp, char* path)
         perror_disp("file cannot be open", 1);
     }
 }
+
+static void fileio_check_ln_length(char* buf, int size);
+
+char* fileio_getfileln(char* buf, int size, FILE** ptr)
+{
+    char* rtrn_val = fgets(buf, size, *ptr);
+
+    if(rtrn_val != NULL)
+    {
+        fileio_check_ln_length(buf, size);
+    }
+
+    return rtrn_val;
+}
+
+static void fileio_check_ln_length(char* buf, int size)
+{
+    int newline_fnd = false;
+
+    for(int i = 0; i < size; i++)
+    {
+        if(buf[i] == '\n') newline_fnd = true;
+    }
+
+    if(!newline_fnd) perror_disp("file string is too long", true);
+}

--- a/src/fileio/fileio.h
+++ b/src/fileio/fileio.h
@@ -22,5 +22,6 @@
 #include <stdio.h>
 
 void fileio_setfileptr(FILE** fp, char* path);
+char* fileio_getfileln(char* buf, int size, FILE** ptr);
 
 #endif

--- a/src/fileio/gameconf.c
+++ b/src/fileio/gameconf.c
@@ -33,27 +33,24 @@ the appropriate value*/
 void gameconf_readfile()
 {
     FILE* fp = fopen("gameconf.txt", "r");
-    char* buf = calloc(P_MAX_BUF_SIZE, sizeof(char));
+    char buf[P_MAX_BUF_SIZE] = {0};
 
     while (fgets(buf, (P_MAX_BUF_SIZE - 1), fp) != NULL)
     {
-        char* var = calloc((P_MAX_BUF_SIZE - 1), sizeof(char));
-        char* value = calloc((P_MAX_BUF_SIZE - 1), sizeof(char));
+        char var[P_MAX_BUF_SIZE - 1] = {0};
+        char value[P_MAX_BUF_SIZE - 1] = {0};
 
         stringsm_chomp(buf);
         stringsm_rtab(buf);
+
         if(strcmp(buf, "") && buf[0] != '*')
         {
             gameconf_splitins(var, value, buf);
             pvars_setgcvars(var, value);
         } 
-
-        free(var);
-        free(value);
     }
 
     fclose(fp);
-    free(buf);
 }
 
 void gameconf_splitins(char* var, char* value, char* ins)

--- a/src/fileio/gameconf.c
+++ b/src/fileio/gameconf.c
@@ -24,6 +24,7 @@
 #include "gameconf.h"
 #include "vars/pconst.h"
 #include "vars/pvars.h"
+#include "fileio/fileio.h"
 #include "stringsm.h"
 
 void gameconf_splitins(char* var, char* value, char* ins);
@@ -35,7 +36,7 @@ void gameconf_readfile()
     FILE* fp = fopen("gameconf.txt", "r");
     char buf[P_MAX_BUF_SIZE] = {0};
 
-    while (fgets(buf, (P_MAX_BUF_SIZE - 1), fp) != NULL)
+    while (fileio_getfileln(buf, P_MAX_BUF_SIZE, &fp) != NULL)
     {
         char var[P_MAX_BUF_SIZE - 1] = {0};
         char value[P_MAX_BUF_SIZE - 1] = {0};

--- a/src/pstrings.cpp
+++ b/src/pstrings.cpp
@@ -46,7 +46,7 @@ static void add_pstring_to_vec(std::string p_id, std::string p_val);
 void pstrings_copy_file_to_vec()
 {
     FILE* fp = NULL;
-    char buf[P_MAX_BUF_SIZE];
+    char buf[P_MAX_BUF_SIZE]{0};
 
     open_strfile(&fp);
     while(fgets(buf, P_MAX_BUF_SIZE - 1, fp) != NULL)

--- a/src/pstrings.cpp
+++ b/src/pstrings.cpp
@@ -49,7 +49,8 @@ void pstrings_copy_file_to_vec()
     char buf[P_MAX_BUF_SIZE]{0};
 
     open_strfile(&fp);
-    while(fgets(buf, P_MAX_BUF_SIZE - 1, fp) != NULL)
+
+    while(fileio_getfileln(buf, P_MAX_BUF_SIZE, &fp) != NULL)
     {
         std::string r_id;
         std::string r_val;

--- a/src/room/room_io.cpp
+++ b/src/room/room_io.cpp
@@ -47,7 +47,7 @@ void roomio_copy_file_to_vec()
 
     open_strfile(&fp);
     
-    while(fgets(buf, P_MAX_BUF_SIZE - 1, fp) != NULL)
+    while(fileio_getfileln(buf, P_MAX_BUF_SIZE, &fp) != NULL)
     {
         stringsm_chomp(buf);
         stringsm_rtab(buf);

--- a/src/room/room_io.cpp
+++ b/src/room/room_io.cpp
@@ -44,10 +44,8 @@ void roomio_copy_file_to_vec()
 {
     char buf[P_MAX_BUF_SIZE]{0};
     FILE* fp = NULL;
-    char* roomfile = NULL;
 
     open_strfile(&fp);
-    pvars_getstdvars("roomfile", &roomfile);
     
     while(fgets(buf, P_MAX_BUF_SIZE - 1, fp) != NULL)
     {
@@ -57,7 +55,6 @@ void roomio_copy_file_to_vec()
         if(*buf != '\0') add_ln_to_vec(buf);
         else continue;
     }
-    free(roomfile);
 }
 
 /*Return a char array containing the line from the specified index*/

--- a/src/stringsm.c
+++ b/src/stringsm.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include "stringsm.h"
+#include "fileio/fileio.h"
 #include "perror.h"
 
 void stringsm_chomp(char* str)
@@ -71,9 +72,11 @@ void stringsm_getfw(char** fw, char* str, int* index)
 /*Get user text input and return it in a pointer*/
 void stringsm_getuseri(char** buf)
 {
+    FILE* fp = stdin;
     char *c = NULL;
 
-    fgets(*buf, (sizeof(*buf) + 1), stdin);
+    fileio_getfileln(*buf, sizeof(*buf), &fp);
+
     if((c = strchr(*buf, '\n')))
     {
         stringsm_chomp(*buf);


### PR DESCRIPTION
This pull request adds a wrapper around the fgets function to throw an error if the file line read is too long. It also fixes a bug with the exitgame function which couldn't display a string to ask the user to press enter.